### PR TITLE
added dependency, python2-gobject in PKGBUILD

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -8,7 +8,7 @@ arch=('any')
 url="https://github.com/robled/rocket-depot"
 license=('GPL3')
 depends=('python2-setuptools' 'xterm' 'hicolor-icon-theme',
-         'rdesktop' 'freerdp' 'python2-gobject2')
+         'rdesktop' 'freerdp' 'python2-gobject2' 'python2-gobject')
 makedepends=('git')
 provides=('rocket-depot-git')
 conflicts=('rocket-depot-git')


### PR DESCRIPTION
Running in arch-linux after installing through AUR or manually with `makepkg -si`, gives an import module error for module named "gi" which is part of gobject library.
Even though `python2-gobject2` is installed, for some reason it's not being recognised by pip2, you can confirm this by running `pip2 list|grep gobject`.

I fixed it by installing `python2-gobject` after doing a quick search on google.
I don't know the difference between `python2-gobject2` and `python2-gobject` that's why I did not replace `python2-gobject2` with `python2-gobject`.